### PR TITLE
Update line 33 in orthopy/e1r2/orth.py

### DIFF
--- a/orthopy/e1r2/orth.py
+++ b/orthopy/e1r2/orth.py
@@ -30,7 +30,7 @@ def recurrence_coefficients(n, standardization, symbolic=False):
     else:
         assert (
             standardization == "normal"
-        ), f"Unknown standardization '{standardization}'."
+        ), "Unknown standardization '{}'.".format(standardization)
         p0 = 1 / sqrt(sqrt(pi))
         a = sqrt(S(2) / (N + 1))
         b = numpy.zeros(n, dtype=int)


### PR DESCRIPTION
Revised line 33 to be more consistent with line 42 in orthopy/e1r/orth.py. I was unable to successfully run the quadpy v. 0.13.2 package without the above change being made to this file.